### PR TITLE
feat: add docker commands to package.json for improved container management

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,21 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "docker:build": "docker build -t movie-hub .",
+    "docker:build:dev": "docker build -t movie-hub:dev --target builder .",
+    "docker:build:prod": "docker build -t movie-hub:prod --target production .",
+    "docker:run": "docker run -p 8080:3000 movie-hub",
+    "docker:run:dev": "docker run -p 8080:3000 movie-hub:dev",
+    "docker:run:prod": "docker run -p 8080:3000 movie-hub:prod",
+    "docker:up": "docker compose up -d",
+    "docker:down": "docker compose down",
+    "docker:logs": "docker compose logs -f",
+    "docker:restart": "docker compose restart",
+    "docker:rebuild": "docker compose down && docker compose build --no-cache && docker compose up -d",
+    "docker:clean": "docker compose down -v --remove-orphans && docker image prune -f",
+    "docker:shell": "docker compose exec app sh",
+    "docker:db": "docker compose exec postgres psql -U moviehub -d moviehub"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^2.1.1",


### PR DESCRIPTION
This pull request adds a suite of Docker-related scripts to the `package.json` file, making it easier to build, run, and manage the application and its dependencies using Docker and Docker Compose.

**Docker integration and management:**

* Added scripts for building Docker images for development and production, as well as running containers with the appropriate tags (`docker:build`, `docker:build:dev`, `docker:build:prod`, `docker:run`, `docker:run:dev`, `docker:run:prod`).
* Added Docker Compose management scripts for starting, stopping, logging, restarting, rebuilding, and cleaning up containers and images (`docker:up`, `docker:down`, `docker:logs`, `docker:restart`, `docker:rebuild`, `docker:clean`).
* Added utility scripts to access a shell inside the app container and connect to the Postgres database (`docker:shell`, `docker:db`).